### PR TITLE
Eh-16

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -25,6 +25,6 @@
 
 #include <string>
 
-const std::string kProgramVersion = "Expansion Hunter v2.0.6";
+const std::string kProgramVersion = "Expansion Hunter v2.0.7";
 
 #endif  // VERSION_H_

--- a/src/bam_file.cc
+++ b/src/bam_file.cc
@@ -422,9 +422,20 @@ double BamFile::CalcMedianDepth(Parameters& parameters, size_t read_len) {
   for (size_t chrom_ind = 0; chrom_ind < chrom_count; ++chrom_ind) {
     const string& chrom_name = chrom_names[chrom_ind];
 
+    bool skip_cur_chrom = false;
     if (chrom_name == "chrX" || chrom_name == "X" || chrom_name == "chrY" ||
         chrom_name == "Y" || chrom_name == "chrM" || chrom_name == "M" ||
         chrom_name == "*" || chrom_name == "MT") {
+      skip_cur_chrom = true;
+    }
+
+    size_t gl_pos = chrom_name.find("GL000");
+    if (gl_pos != std::string::npos) {
+      skip_cur_chrom = true;
+    }
+
+    if (skip_cur_chrom) {
+      cerr << "[Skipping " << chrom_name << " during depth calculation]" << endl;
       continue;
     }
 

--- a/src/expansion_hunter.cc
+++ b/src/expansion_hunter.cc
@@ -91,7 +91,7 @@ size_t CalcReadLen(const string& bam_path) {
   bam_destroy1(align_ptr);
   bam_hdr_destroy(header_ptr);
   sam_close(file_ptr);
-  
+
   return read_len;
 }
 
@@ -192,13 +192,13 @@ void CacheAligns(BamFile* bam_file, const RepeatSpec& repeat_spec,
   }
 
   // Filling-in missing mates by jumping around the BAM.
-  // cerr << "\t[Filling in mates]" << endl;
-  // if ((*bam_file).format() == BamFile::kBamFile) {
-  //   FillinMates(*bam_file, align_pairs);
-  // } else {
-  //   cerr << "\t[Skipping filling in mates]" << endl;
-  // }
-  // cerr << "\t[Done filling in mates]" << endl;
+  cerr << "\t[Filling in mates]" << endl;
+  if ((*bam_file).format() == BamFile::kBamFile) {
+    FillinMates(*bam_file, align_pairs);
+  } else {
+    cerr << "\t[Skipping filling in mates]" << endl;
+  }
+  cerr << "\t[Done filling in mates]" << endl;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
 - Non-primary alignments are skipped during read length determination
 - Mates of on-target reads are extracted even if they are located outside of off-target regions
 - Contigs whose name contains GL000 are skipped during median depth calculation; if this is not appropriate, the correct depth should be specified as a program option  