### PR TITLE
Read caching

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <string>
 
+
 enum class ReadType { kSpanning, kFlanking, kInrepeat, kOther };
 const std::map<ReadType, std::string> kReadTypeToString = {
     {ReadType::kInrepeat, "INREPEAT"},

--- a/common/repeat_spec.cc
+++ b/common/repeat_spec.cc
@@ -20,26 +20,27 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <string>
-#include <fstream>
 #include <cassert>
-#include <set>
+#include <fstream>
 #include <iostream>
-#include <sstream>
-#include <vector>
 #include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
 
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/optional/optional.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/filesystem.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include <boost/regex.hpp>
-#include <boost/algorithm/string/join.hpp>
+#include <boost/tokenizer.hpp>
 
 #include "common/ref_genome.h"
 #include "common/repeat_spec.h"
+#include "common/timestamp.h"
 #include "purity/purity.h"
 
 using std::string;
@@ -62,7 +63,7 @@ const char RepeatSpec::LeftFlankBase() const {
   return left_flank[left_flank.size() - 1];
 }
 
-RepeatSpec::RepeatSpec(const string& json_path) {
+RepeatSpec::RepeatSpec(const string &json_path) {
   std::ifstream istrm(json_path.c_str());
 
   if (!istrm.is_open()) {
@@ -104,21 +105,21 @@ RepeatSpec::RepeatSpec(const string& json_path) {
 
   if (confusion_node) {
     offtarget_regions.clear();
-    for (const ptree::value_type& region_node : *confusion_node) {
-      assert(region_node.first.empty());  // array elements have no names
+    for (const ptree::value_type &region_node : *confusion_node) {
+      assert(region_node.first.empty()); // array elements have no names
       offtarget_regions.push_back(Region(region_node.second.data()));
     }
   }
 }
 
 // Fill out prefix and suffix sequences.
-bool LoadFlanks(const string& genome_path, double min_wp,
-                RepeatSpec* repeat_spec) {
+bool LoadFlanks(const string &genome_path, double min_wp,
+                RepeatSpec *repeat_spec) {
   RefGenome ref_genome(genome_path);
   // Reference repeat flanks should be at least as long as reads.
   const int kFlankLen = 250;
 
-  const Region& repeat_region = repeat_spec->target_region;
+  const Region &repeat_region = repeat_spec->target_region;
 
   const int64_t left_flank_begin = repeat_region.start() - kFlankLen;
   const int64_t left_flank_end = repeat_region.start() - 1;
@@ -155,8 +156,8 @@ bool LoadFlanks(const string& genome_path, double min_wp,
   return true;
 }
 
-bool LoadRepeatSpecs(const string& specs_path, const string& genome_path,
-                     double min_wp, map<string, RepeatSpec>* repeat_specs) {
+bool LoadRepeatSpecs(const string &specs_path, const string &genome_path,
+                     double min_wp, map<string, RepeatSpec> *repeat_specs) {
   assert(!specs_path.empty());
 
   const boost::regex regex_json(".*\\.json$");
@@ -169,7 +170,7 @@ bool LoadRepeatSpecs(const string& specs_path, const string& genome_path,
       boost::smatch what;
 
       if (boost::regex_match(fname, what, regex_json)) {
-        cerr << "[Loading " << fname << "]" << endl;
+        cerr << TimeStamp() << ",[Loading " << fname << "]" << endl;
 
         const string json_path = itr->path().string();
         RepeatSpec repeat_spec(json_path);

--- a/common/timestamp.cc
+++ b/common/timestamp.cc
@@ -1,0 +1,25 @@
+// Concept: Michael Eberle <meberle@illumina.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "common/timestamp.h"
+
+std::string TimeStamp() {
+  std::time_t now = time(0);
+  const size_t timestamp_size = 80;
+  char timestamp_buf[timestamp_size];
+  std::strftime(timestamp_buf, timestamp_size, "%FT%T", std::localtime(&now));
+  return std::string(timestamp_buf);
+}

--- a/common/timestamp.h
+++ b/common/timestamp.h
@@ -1,0 +1,28 @@
+//
+// Expansion Hunter
+// Copyright (c) 2016 Illumina, Inc.
+//
+// Author: Egor Dolzhenko <edolzhenko@illumina.com>,
+//         Mitch Bekritsky <mbekritsky@illumina.com>, Richard Shaw
+// Concept: Michael Eberle <meberle@illumina.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <string>
+#include <chrono>
+
+std::string TimeStamp();

--- a/genotyping/short_repeat_genotyper.cc
+++ b/genotyping/short_repeat_genotyper.cc
@@ -23,7 +23,7 @@
 #include "genotyping/short_repeat_genotyper.h"
 
 #include <algorithm>
-#import <cassert>
+#include <cassert>
 #include <cctype>
 #include <cmath>
 #include <iostream>

--- a/include/irr_counting.h
+++ b/include/irr_counting.h
@@ -22,10 +22,10 @@
 
 #pragma once
 
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-#include <string>
 #include <vector>
 
 #include "common/genomic_region.h"
@@ -46,31 +46,33 @@ enum WhatToCache { kCacheAll, kCacheIrr };
 
 // Extract alignment pairs from a specified region.
 void CacheReadsFromRegion(
-    const Region& region, const WhatToCache whatToCache,
-    const std::vector<std::vector<std::string>>& units_shifts,
-    double min_wp_score, BamFile* bam_file, AlignPairs* align_pairs);
+    const Region &region, const WhatToCache whatToCache,
+    const std::vector<std::vector<std::string>> &units_shifts,
+    double min_wp_score, BamFile *bam_file, AlignPairs *align_pairs);
 
 void CountAnchoredIrrs(
-    const BamFile& bam_file, const Parameters& parameters,
-    const Region& target_neighborhood, const RepeatSpec& repeat_spec,
-    const std::unordered_set<std::string>& ontarget_frag_names,
-    AlignPairs& align_pairs, int& num_anchored_irrs,
-    const std::vector<std::vector<std::string>>& units_shifts,
-    std::vector<RepeatAlign>* anchored_irrs);
+    const BamFile &bam_file, const Parameters &parameters,
+    const Region &target_neighborhood, const RepeatSpec &repeat_spec,
+    const std::unordered_set<std::string> &ontarget_frag_names,
+    AlignPairs &align_pairs, int &num_anchored_irrs,
+    const std::vector<std::vector<std::string>> &units_shifts,
+    std::vector<RepeatAlign> *anchored_irrs);
 
-void FillinMates(BamFile& bam_file, AlignPairs& align_pairs);
+void FillinMates(BamFile &bam_file, AlignPairs &align_pairs,
+                 const std::vector<std::vector<std::string>> &units_shifts,
+                 double min_wp_score,
+                 const std::unordered_set<std::string> &ontarget_frag_names);
 
 // Count the number of in-repeat reads stored in an AlignPairs object.
 // A fragment is in-repeat if both of the reads fuzzy match to the repeat
 // sequence.
 bool CountUnalignedIrrs(
-    BamFile& bam_file, const Parameters& parameters, int& numInRepeatReads,
-    const std::vector<std::vector<std::string>>& units_shifts,
-    std::vector<RepeatAlign>* irr_rep_aligns);
+    BamFile &bam_file, const Parameters &parameters, int &numInRepeatReads,
+    const std::vector<std::vector<std::string>> &units_shifts,
+    std::vector<RepeatAlign> *irr_rep_aligns);
 
-int CountAlignedIrr(
-    const BamFile& bam_file, const Parameters& parameters,
-    const AlignPairs& align_pairs,
-    std::map<std::string, int>& num_irrs_per_offtarget_region,
-    const std::vector<std::vector<std::string>>& units_shifts,
-    std::vector<RepeatAlign>* irr_rep_aligns);
+int CountAlignedIrr(const BamFile &bam_file, const Parameters &parameters,
+                    const AlignPairs &align_pairs,
+                    std::map<std::string, int> &num_irrs_per_offtarget_region,
+                    const std::vector<std::vector<std::string>> &units_shifts,
+                    std::vector<RepeatAlign> *irr_rep_aligns);

--- a/include/version.h
+++ b/include/version.h
@@ -24,4 +24,4 @@
 
 #include <string>
 
-const std::string kProgramVersion = "Expansion Hunter v2.5.1";
+const std::string kProgramVersion = "Expansion Hunter v2.5.2";

--- a/src/bam_file.cc
+++ b/src/bam_file.cc
@@ -95,7 +95,14 @@ void BamFile::Init(const string &path, const string &reference) {
     }
   }
 
-  cerr << "[Input format: " << format_ << "]" << endl;
+  string input_format = "Unknown";
+  if (format_ == kBamFile) {
+    input_format = "BAM";
+  } else if (format_ == kCramFile) {
+    input_format = "CRAM";
+  }
+
+  cerr << TimeStamp() << ",[Input format: " << input_format << "]" << endl;
 
   // Read hdr and set up ref_vec_
   hts_bam_hdr_ptr_ = sam_hdr_read(hts_file_ptr_);

--- a/src/bam_file.cc
+++ b/src/bam_file.cc
@@ -41,6 +41,7 @@
 
 #include "common/parameters.h"
 #include "common/ref_genome.h"
+#include "common/timestamp.h"
 #include "include/bam_index.h"
 
 typedef boost::tokenizer<boost::char_separator<char>> Tokenizer;
@@ -412,7 +413,7 @@ double BamFile::CalcMedianDepth(Parameters &parameters, size_t read_len) {
     }
 
     if (skip_cur_chrom) {
-      cerr << "[Skipping " << chrom_name << " during depth calculation]"
+      cerr << TimeStamp() << ",[Skipping " << chrom_name << " during depth calculation]"
            << endl;
       continue;
     }

--- a/src/expansion_hunter.cc
+++ b/src/expansion_hunter.cc
@@ -27,7 +27,6 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <chrono>
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -39,6 +38,7 @@
 
 #include "common/parameters.h"
 #include "common/ref_genome.h"
+#include "common/timestamp.h"
 #include "genotyping/repeat_genotyper.h"
 #include "include/bam_file.h"
 #include "include/bam_index.h"
@@ -59,14 +59,6 @@ using std::cerr;
 using std::endl;
 using std::pair;
 using std::array;
-
-string TimeStamp() {
-  std::time_t now = time(0);
-  const size_t timestamp_size = 80;
-  char timestamp_buf[timestamp_size];
-  std::strftime(timestamp_buf, timestamp_size, "%FT%T", std::localtime(&now));
-  return string(timestamp_buf);
-}
 
 // Returns the length of the first read in a BAM file.
 size_t CalcReadLen(const string &bam_path) {

--- a/src/expansion_hunter.cc
+++ b/src/expansion_hunter.cc
@@ -60,12 +60,12 @@ using std::endl;
 using std::pair;
 using std::array;
 
-std::string TimeStamp() {
-  std::time_t now =
-      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  std::stringstream ss;
-  ss << std::put_time(std::localtime(&now), "%FT%T");
-  return ss.str();
+string TimeStamp() {
+  std::time_t now = time(0);
+  const size_t timestamp_size = 80;
+  char timestamp_buf[timestamp_size];
+  std::strftime(timestamp_buf, timestamp_size, "%FT%T", std::localtime(&now));
+  return string(timestamp_buf);
 }
 
 // Returns the length of the first read in a BAM file.

--- a/src/expansion_hunter.cc
+++ b/src/expansion_hunter.cc
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <chrono>
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -58,6 +59,14 @@ using std::cerr;
 using std::endl;
 using std::pair;
 using std::array;
+
+std::string TimeStamp() {
+  std::time_t now =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  std::stringstream ss;
+  ss << std::put_time(std::localtime(&now), "%FT%T");
+  return ss.str();
+}
 
 // Returns the length of the first read in a BAM file.
 size_t CalcReadLen(const string &bam_path) {
@@ -177,8 +186,8 @@ void CacheAligns(BamFile *bam_file, const RepeatSpec &repeat_spec,
     ontarget_frag_names.insert(name);
   }
 
-  cerr << "\t[Found " << ontarget_frag_names.size() << " reads in target locus]"
-       << endl;
+  cerr << TimeStamp() << ",\t[Found " << ontarget_frag_names.size()
+       << " reads in target locus]" << endl;
 
   // Cache aligned off-target reads.
   for (const Region &confusion_region : repeat_spec.offtarget_regions) {
@@ -189,14 +198,14 @@ void CacheAligns(BamFile *bam_file, const RepeatSpec &repeat_spec,
   }
 
   // Filling-in missing mates by jumping around the BAM.
-  cerr << "\t[Filling in mates]" << endl;
+  cerr << TimeStamp() << ",\t[Filling in mates]" << endl;
   if ((*bam_file).format() == BamFile::kBamFile) {
     FillinMates(*bam_file, align_pairs, repeat_spec.units_shifts, 0.9,
                 ontarget_frag_names);
   } else {
-    cerr << "\t[Skipping filling in mates]" << endl;
+    cerr << TimeStamp() << ",\t[Skipping filling in mates]" << endl;
   }
-  cerr << "\t[Done filling in mates]" << endl;
+  cerr << TimeStamp() << ",\t[Done filling in mates]" << endl;
 }
 
 bool IsFlannkingGroup(const RepeatReadGroup &read_group) {
@@ -219,9 +228,10 @@ bool FindLongRepeats(const Parameters &parameters,
                     region_findings.num_anchored_irrs, repeat_spec.units_shifts,
                     &irr_rep_aligns);
 
-  cerr << "\t[Found " << region_findings.num_anchored_irrs << " anchored IRRs]"
-       << endl
-       << "\t[Cached " << align_pairs.size() << " reads]" << endl;
+  cerr << TimeStamp() << ",\t[Found " << region_findings.num_anchored_irrs
+       << " anchored IRRs]" << endl
+       << TimeStamp() << ",\t[Cached " << align_pairs.size() << " reads]"
+       << endl;
 
   // Stores the total IRR count.
   region_findings.num_irrs = region_findings.num_anchored_irrs;
@@ -229,7 +239,7 @@ bool FindLongRepeats(const Parameters &parameters,
   // Look for IRR pairs only if anchored IRRs are found.
   if (region_findings.num_anchored_irrs) {
     if (!repeat_spec.is_common_unit()) {
-      cerr << "\t[Counting aligned IRR pairs]" << endl;
+      cerr << TimeStamp() << ",\t[Counting aligned IRR pairs]" << endl;
       map<string, int> numIrrConfRegion;
       region_findings.num_irrs +=
           CountAlignedIrr(bam_file, parameters, align_pairs, numIrrConfRegion,
@@ -246,13 +256,13 @@ bool FindLongRepeats(const Parameters &parameters,
       region_findings.num_unaligned_irrs = 0;
 
       if (!parameters.skip_unaligned()) {
-        cerr << "\t[Counting unaligned IRRs]" << endl;
+        cerr << TimeStamp() << ",\t[Counting unaligned IRRs]" << endl;
         CountUnalignedIrrs(bam_file, parameters,
                            region_findings.num_unaligned_irrs,
                            repeat_spec.units_shifts, &irr_rep_aligns);
         region_findings.num_irrs += region_findings.num_unaligned_irrs;
       } else {
-        cerr << "\t[Skipping unaligned IRRs]" << endl;
+        cerr << TimeStamp() << ",\t[Skipping unaligned IRRs]" << endl;
       }
     }
 
@@ -319,12 +329,12 @@ void EstimateRepeatSizes(const Parameters &parameters,
         parameters.sex() == Sex::kFemale && (chrom == "chrY" || chrom == "Y");
 
     if (is_female_chrom_y) {
-      cerr << "[Skipping " << repeat_header << " because the sample is female]"
-           << endl;
+      cerr << TimeStamp() << ",[Skipping " << repeat_header
+           << " because the sample is female]" << endl;
       continue;
     }
 
-    cerr << "[Analyzing " << repeat_header << "]" << endl;
+    cerr << TimeStamp() << ",[Analyzing " << repeat_header << "]" << endl;
 
     const bool is_sex_chrom =
         chrom == "chrX" || chrom == "X" || chrom == "chrY" || chrom == "Y";
@@ -339,22 +349,23 @@ void EstimateRepeatSizes(const Parameters &parameters,
     region_findings.offtarget_irr_counts =
         vector<int>(repeat_spec.offtarget_regions.size(), 0);
 
-    cerr << "\t[Caching reads]" << endl;
+    cerr << TimeStamp() << ",\t[Caching reads]" << endl;
     AlignPairs align_pairs;
     unordered_set<string> ontarget_frag_names;
     CacheAligns(&(*bam_file), repeat_spec, align_pairs, ontarget_frag_names,
                 parameters.region_extension_len());
     if (align_pairs.empty()) {
-      cerr << "\t[Found no on-target or off-target reads]" << endl;
+      cerr << TimeStamp() << ",\t[Found no on-target or off-target reads]"
+           << endl;
       continue;
     }
 
-    cerr << "\t[Estimating short repeat sizes]" << endl;
+    cerr << TimeStamp() << ",\t[Estimating short repeat sizes]" << endl;
     FindShortRepeats(parameters, *bam_file, repeat_spec, align_pairs,
                      region_findings.read_groups,
                      &region_findings.flanking_repaligns);
 
-    cerr << "\t[Estimating long repeat sizes]" << endl;
+    cerr << TimeStamp() << ",\t[Estimating long repeat sizes]" << endl;
     region_findings.num_anchored_irrs = 0;
     region_findings.num_unaligned_irrs = 0;
     region_findings.num_irrs = 0;
@@ -376,8 +387,6 @@ void EstimateRepeatSizes(const Parameters &parameters,
     vector<RepeatAllele> haplotype_candidates;
     // Add count of in-repeat reads to flanking.
     for (const auto &read_group : region_findings.read_groups) {
-      cerr << kReadTypeToString.at(read_group.read_type) << endl;
-
       if (read_group.read_type == ReadType::kSpanning) {
         spanning_size_counts[read_group.size] +=
             read_group.num_supporting_reads;
@@ -407,24 +416,27 @@ void EstimateRepeatSizes(const Parameters &parameters,
       }
     }
 
-    cerr << "Flanking:" << endl;
+    cerr << TimeStamp() << ",\t[Flanking:";
     for (const auto &kv : flanking_size_counts) {
-      cerr << "\t" << kv.first << " -- " << kv.second << endl;
+      cerr << " (" << kv.first << ", " << kv.second << ")";
     }
+    cerr << "]" << endl;
 
-    cerr << "Spanning:" << endl;
+    cerr << TimeStamp() << ",\t[Spanning:";
     for (const auto &kv : spanning_size_counts) {
-      cerr << "\t" << kv.first << " -- " << kv.second << endl;
+      cerr << " (" << kv.first << ", " << kv.second << ")";
     }
+    cerr << "]" << endl;
 
-    cerr << "Haplotype candidates: ";
+    cerr << TimeStamp() << ",\t[Haplotype candidates:";
     for (const auto &candiate : haplotype_candidates) {
-      cerr << candiate.size_ << " ";
+      cerr << " " << candiate.size_;
     }
-    cerr << endl;
+    cerr << "]" << endl;
 
     if (haplotype_candidates.empty()) {
-      cerr << "\t[Skipping this region because no informative reads were found]"
+      cerr << TimeStamp()
+           << ",\t[Skipping this region because no informative reads were found]"
            << endl;
       continue;
     }
@@ -455,7 +467,7 @@ void EstimateRepeatSizes(const Parameters &parameters,
             CompareRegionFindings);
   WriteJson(parameters, repeat_specs, sample_findings, outputs->json());
   WriteVcf(parameters, repeat_specs, sample_findings, outputs->vcf());
-  cerr << "[All done]" << endl;
+  cerr << TimeStamp() << ",[All done]" << endl;
 }
 
 int main(int argc, char *argv[]) {
@@ -467,7 +479,9 @@ int main(int argc, char *argv[]) {
       return 1;
     }
 
-    Outputs outputs(parameters.vcf_path(), parameters.json_path(),
+    cerr << TimeStamp() << ",[Starting Logging for " << parameters.sample_name() << "]" << endl;
+
+         Outputs outputs(parameters.vcf_path(), parameters.json_path(),
                     parameters.log_path());
 
     map<string, RepeatSpec> repeat_specs;
@@ -485,17 +499,15 @@ int main(int argc, char *argv[]) {
     BamFile bam_file;
     bam_file.Init(parameters.bam_path(), parameters.genome_path());
 
-    cerr << "[Sample " << parameters.sample_name() << "]" << endl;
-
     if (!parameters.depth_is_set()) {
-      cerr << "[Calculating depth]" << endl;
+      cerr << TimeStamp() << ",[Calculating depth]" << endl;
       const double depth =
           bam_file.CalcMedianDepth(parameters, parameters.read_len());
       parameters.set_depth(depth);
     }
 
-    cerr << "[Read length: " << parameters.read_len() << "]" << endl;
-    cerr << "[Depth: " << parameters.depth() << "]" << endl;
+    cerr << TimeStamp() << ",[Read length: " << parameters.read_len() << "]" << endl;
+    cerr << TimeStamp() << ",[Depth: " << parameters.depth() << "]" << endl;
 
     if (parameters.depth() < parameters.kSmallestPossibleDepth) {
       throw std::runtime_error("Estimated depth of " +

--- a/src/expansion_hunter.cc
+++ b/src/expansion_hunter.cc
@@ -191,7 +191,8 @@ void CacheAligns(BamFile *bam_file, const RepeatSpec &repeat_spec,
   // Filling-in missing mates by jumping around the BAM.
   cerr << "\t[Filling in mates]" << endl;
   if ((*bam_file).format() == BamFile::kBamFile) {
-    FillinMates(*bam_file, align_pairs);
+    FillinMates(*bam_file, align_pairs, repeat_spec.units_shifts, 0.9,
+                ontarget_frag_names);
   } else {
     cerr << "\t[Skipping filling in mates]" << endl;
   }

--- a/src/irr_counting.cc
+++ b/src/irr_counting.cc
@@ -22,25 +22,25 @@
 
 #include "include/irr_counting.h"
 
-#include <string>
-using std::string;
-#include <iostream>
-using std::endl;
-using std::cerr;
-#include <unordered_set>
-using std::unordered_set;
-#include <vector>
-using std::vector;
-#include <map>
-using std::map;
 #include <algorithm>
-using std::array;
 #include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
+#include "common/timestamp.h"
 #include "purity/purity.h"
 #include "rep_align/rep_align.h"
 
-/*****************************************************************************/
+using std::string;
+using std::endl;
+using std::cerr;
+using std::unordered_set;
+using std::vector;
+using std::map;
+using std::array;
 
 // Check if two alignments are same.
 static bool SameAlign(Align &al1, Align &al2) {
@@ -141,13 +141,13 @@ bool CheckAnchoredIrrs(const BamFile &bam_file, const Parameters &parameters,
       mate_align.GetReadRegion(mateRegion, bam_file.ref_vec());
 
       if (!mateRegion.Overlaps(target_neighborhood)) {
-        cerr << "Discarding IRR " << read_align.name << " read"
-             << (read_align.IsFirstMate() ? "1" : "2") << read_align.pos
-             << " MAPQ " << read_align.mapq << ") because anchoring mate "
-             << mate_align.name << " read"
+        cerr << TimeStamp() << ",\t[Discarding IRR " << read_align.name
+             << " read" << (read_align.IsFirstMate() ? "1" : "2")
+             << read_align.pos << " MAPQ " << read_align.mapq
+             << ") because anchoring mate " << mate_align.name << " read"
              << (mate_align.IsFirstMate() ? "1" : "2") << mate_align.pos
              << " MAPQ " << mate_align.mapq << ") not on target ("
-             << target_neighborhood << ")" << endl;
+             << target_neighborhood << ")]" << endl;
         return false;
       }
     }

--- a/src/irr_counting.cc
+++ b/src/irr_counting.cc
@@ -92,7 +92,8 @@ void CacheReadsFromRegion(const Region &region, const WhatToCache whatToCache,
           frag[0] = align;
         } else {
           if (!SameAlign(frag[0], align)) {
-            cerr << "[WARNING: There are multiple first mates named \""
+            cerr << TimeStamp()
+                 << ",\t[WARNING: There are multiple first mates named \""
                  << frag[0].name << "\"]" << endl;
           }
         }
@@ -101,7 +102,8 @@ void CacheReadsFromRegion(const Region &region, const WhatToCache whatToCache,
           frag[1] = align;
         } else {
           if (!SameAlign(frag[1], align)) {
-            cerr << "[WARNING: There are multiple second mates named \""
+            cerr << TimeStamp()
+                 << ",\t[WARNING: There are multiple second mates named \""
                  << frag[1].name << "\"]" << endl;
           }
         }
@@ -236,11 +238,11 @@ bool CountUnalignedIrrs(BamFile &bam_file, const Parameters &parameters,
   AlignPairs align_pairs;
   Region unalignedRegion("*", 0, 0, "");
 
-  cerr << "\t[Caching unaligned IRRs]" << endl;
+  cerr << TimeStamp() << ",\t[Caching unaligned IRRs]" << endl;
   CacheReadsFromRegion(unalignedRegion, kCacheIrr, units_shifts,
                        parameters.min_wp(), &bam_file, &align_pairs);
 
-  cerr << "\t[Done; cached " << align_pairs.size()
+  cerr << TimeStamp() << ",\t[Done; cached " << align_pairs.size()
        << " unaligned fragments containing at least one IRR read]" << endl;
 
   for (AlignPairs::const_iterator it = align_pairs.begin();

--- a/src/read_group.cc
+++ b/src/read_group.cc
@@ -150,9 +150,9 @@ void CoalesceFlankingReads(const RepeatSpec &repeat_spec,
             MatchRepeat(units, piece_bases, piece_quals, min_baseq);
       }
 
-      if (0.7 > flank_wp || flank_wp > 1.0) {
-        cerr << "[WARNING: flank_wp = " << flank_wp << "]" << endl;
-      }
+      //if (0.7 > flank_wp || flank_wp > 1.0) {
+      //  cerr << "[WARNING: flank_wp = " << flank_wp << "]" << endl;
+      //}
 
       piece_wp_score /= piece_bases.length();
 
@@ -163,8 +163,8 @@ void CoalesceFlankingReads(const RepeatSpec &repeat_spec,
           longest_flanking = rep_align.size;
         }
       } else {
-        cerr << "\t[Discarding flanking read " << rep_align.read.name << " "
-             << rep_align.read.bases << "]" << endl;
+        //cerr << "\t[Discarding flanking read " << rep_align.read.name << " "
+        //     << rep_align.read.bases << "]" << endl;
       }
     } else {
       good_flanking_repaligns.push_back(rep_align);
@@ -185,9 +185,9 @@ void CoalesceFlankingReads(const RepeatSpec &repeat_spec,
     }
     *flanking_repaligns = short_aligns;
 
-    cerr << "\t[Found " << num_reads_from_unseen_allele
-         << " flanking reads longer with long repeat]" << endl;
-    cerr << "\t[longest_flanking = " << longest_flanking << "]" << endl;
+    //cerr << "\t[Found " << num_reads_from_unseen_allele
+    //     << " flanking reads longer with long repeat]" << endl;
+    //cerr << "\t[longest_flanking = " << longest_flanking << "]" << endl;
 
     RepeatReadGroup read_group;
     read_group.read_type = ReadType::kFlanking;

--- a/src/read_group.cc
+++ b/src/read_group.cc
@@ -75,15 +75,15 @@ void CoalesceFlankingReads(const RepeatSpec &repeat_spec,
     }
   }
 
-  cerr << "\t[Longest spanning allele has size " << longest_spanning << "]"
-       << endl;
+  //cerr << "\t[Longest spanning allele has size " << longest_spanning << "]"
+  //     << endl;
 
   bool good_repeat_exists = false;
   int num_reads_from_unseen_allele = 0;
   int longest_flanking = 0;
 
-  cerr << "\t[There are " << flanking_repaligns->size() << " flanking reads]"
-       << endl;
+  //cerr << "\t[There are " << flanking_repaligns->size() << " flanking reads]"
+  //     << endl;
 
   vector<RepeatAlign> good_flanking_repaligns;
 
@@ -374,14 +374,14 @@ void DistributeFlankingReads(const Parameters &parameters,
               right_flank_ref_units, bases_suffix.begin(), bases_suffix.end(),
               quals_suffix.begin(), quals_suffix.end(), parameters.min_baseq());
           if (right_flank_score / bases_suffix.length() >= kWpCutoff) {
-            cerr << "[Reasign flanking to spanning]" << endl;
-            Plot plot;
-            const string cased_bases =
-                LowerLowqualBases(bases, quals, parameters.min_baseq());
-            PlotSpanningAlign(plot, cased_bases, left_flank, right_flank,
-                              rep_align.left_flank_len, bases_suffix.length());
-            PlotToStream(cerr, plot);
-            cerr << endl;
+            // cerr << "[Reasign flanking to spanning]" << endl;
+            // Plot plot;
+            // const string cased_bases =
+            //     LowerLowqualBases(bases, quals, parameters.min_baseq());
+            // PlotSpanningAlign(plot, cased_bases, left_flank, right_flank,
+            //                   rep_align.left_flank_len, bases_suffix.length());
+            // PlotToStream(cerr, plot);
+            // cerr << endl;
 
             found_align = true;
             rep_align.right_flank_len = bases_suffix.length();

--- a/src/read_group.cc
+++ b/src/read_group.cc
@@ -403,14 +403,14 @@ void DistributeFlankingReads(const Parameters &parameters,
               quals_prefix.begin(), quals_prefix.end(), parameters.min_baseq());
 
           if (left_flank_score / bases_prefix.length() >= kWpCutoff) {
-            cerr << "[Reasign flanking to spanning]" << endl;
-            Plot plot;
-            const string cased_bases =
-                LowerLowqualBases(bases, quals, parameters.min_baseq());
-            PlotSpanningAlign(plot, cased_bases, left_flank, right_flank,
-                              bases_prefix.length(), rep_align.right_flank_len);
-            PlotToStream(cerr, plot);
-            cerr << endl;
+            //cerr << "[Reasign flanking to spanning]" << endl;
+            //Plot plot;
+            //const string cased_bases =
+            //    LowerLowqualBases(bases, quals, parameters.min_baseq());
+            //PlotSpanningAlign(plot, cased_bases, left_flank, right_flank,
+            //                  bases_prefix.length(), rep_align.right_flank_len);
+            //PlotToStream(cerr, plot);
+            //cerr << endl;
 
             found_align = true;
             rep_align.left_flank_len = bases_prefix.length();


### PR DESCRIPTION
Summary of changes:
 - mates of off-target reads are rescued only for in-repeat reads,
 - timestaps in the log.