### PR TITLE
added read-length optional cmd line argument

### DIFF
--- a/common/parameters.cc
+++ b/common/parameters.cc
@@ -114,7 +114,8 @@ bool Parameters::Load(int argc, char **argv) {
       ("min-anchor-mapq", po::value<int>()->default_value(60), "Minimum MAPQ of a read anchor")
       ("skip-unaligned", po::bool_switch()->default_value(false), "Skip unaligned reads when searching for IRRs")
       ("read-depth", po::value<double>()->default_value(0.0, "calculated if not set"), "Read depth")
-      ("sex", po::value<string>()->default_value("female"), "Sex of the sample; must be either male or female");
+      ("sex", po::value<string>()->default_value("female"), "Sex of the sample; must be either male or female")
+      ("read-length",po::value<int>()->default_value(0, "calculated if not set"), "Read sequence length");
   // clang-format on
 
   if (argc == 1) {
@@ -200,5 +201,13 @@ bool Parameters::Load(int argc, char **argv) {
         " is invalid for sex; must be either male or female");
   }
 
+  if (!arg_map["read-length"].defaulted()) {
+    read_len_ = arg_map["read-length"].as<int>();
+
+    if (read_len_ < minReadLength) {
+      throw std::invalid_argument("read-length must be at least " +
+                                  std::to_string(minReadLength));
+    }
+  }
   return true;
 }

--- a/common/parameters.h
+++ b/common/parameters.h
@@ -47,6 +47,7 @@ class Outputs {
 class Parameters {
  public:
   const double kSmallestPossibleDepth = 5.0;
+  const int minReadLength = 10;
   Parameters()
       : region_extension_len_(1000),
         min_wp_(0.90),
@@ -54,6 +55,7 @@ class Parameters {
         min_anchor_mapq_(60),
         skip_unaligned_(false),
         depth_(0.0),
+        read_len_(0),
         sex_(Sex::kFemale) {}
   bool Load(int argc, char **argv);
   std::string bam_path() const { return bam_path_; }
@@ -76,6 +78,7 @@ class Parameters {
   std::string log_path() const { return log_path_; }
   bool depth_is_set() const { return depth_ >= kSmallestPossibleDepth; }
   Sex sex() const { return sex_; }
+  bool read_len_is_set() const { return read_len_ >= minReadLength; }
 
  private:
   std::string bam_path_;

--- a/src/expansion_hunter.cc
+++ b/src/expansion_hunter.cc
@@ -480,8 +480,16 @@ int main(int argc, char *argv[]) {
           parameters.repeat_specs_path() + "'");
     }
 
-    const int read_len = CalcReadLen(parameters.bam_path());
-    parameters.set_read_len(read_len);
+    if (!parameters.read_len_is_set()) {
+      const int read_len = CalcReadLen(parameters.bam_path());
+      if (read_len < parameters.minReadLength) {
+        throw std::runtime_error("Read length=" +
+                                 lexical_cast<string>(read_len) +
+                                 " determined from first alignment" +
+                                 " is too small.");
+      }
+      parameters.set_read_len(read_len);
+    }
 
     BamFile bam_file;
     bam_file.Init(parameters.bam_path(), parameters.genome_path());


### PR DESCRIPTION
Currently, the read_len parameter is set by the sequence length of the first primary alignment in the input BAM file.  For BAM files generated from variable length reads, the first primary alignment may have a very different sequence length from typical reads in the dataset.  This can lead to erroneous estimates for repeat expansion allele lengths.

With the changes included here, the user may specify the read length as a command line argument (e.g. "--read-length 150).  If the specified length is longer than the minReadLength (10), then the read_len parameter will be set to this length, instead of being set to the seq length of of the first primary alignment in the BAM.