### PR TITLE
Fix #87 - Add PABPN1 to the variant catalog.

### DIFF
--- a/variant_catalog/grch37/variant_catalog.json
+++ b/variant_catalog/grch37/variant_catalog.json
@@ -282,5 +282,11 @@
         "LocusStructure": "(AARRG)*",
         "ReferenceRegion": "4:39350044-39350099",
         "VariantType": "Repeat"
+    },
+    {
+        "LocusId": "PABPN1",
+        "VariantType": "Repeat",
+        "LocusStructure": "(GCG)*",
+        "ReferenceRegion": "14:23790681-23790699"
     }
 ]

--- a/variant_catalog/grch38/variant_catalog.json
+++ b/variant_catalog/grch38/variant_catalog.json
@@ -528,5 +528,11 @@
         "LocusStructure": "(AARRG)*",
         "ReferenceRegion": "4:39348424-39348479",
         "VariantType": "Repeat"
+    },
+    {
+        "VariantType": "Repeat",
+        "LocusId": "PABPN1",
+        "LocusStructure": "(GCG)*",
+        "ReferenceRegion": "14:23321472-23321490"
     }
 ]

--- a/variant_catalog/hg19/variant_catalog.json
+++ b/variant_catalog/hg19/variant_catalog.json
@@ -282,5 +282,11 @@
         "LocusStructure": "(AARRG)*",
         "ReferenceRegion": "chr4:39350044-39350099",
         "VariantType": "Repeat"
+    },
+    {
+        "LocusId": "PABPN1",
+        "VariantType": "Repeat",
+        "LocusStructure": "(GCG)*",
+        "ReferenceRegion": "chr14:23790681-23790699"
     }
 ]

--- a/variant_catalog/hg38/variant_catalog.json
+++ b/variant_catalog/hg38/variant_catalog.json
@@ -528,5 +528,11 @@
         "LocusStructure": "(AARRG)*",
         "ReferenceRegion": "chr4:39348424-39348479",
         "VariantType": "Repeat"
+    },
+    {
+        "VariantType": "Repeat",
+        "LocusId": "PABPN1",
+        "LocusStructure": "(GCG)*",
+        "ReferenceRegion": "chr14:23321472-23321490"
     }
 ]


### PR DESCRIPTION
Add PABPN1; see thread on #87. 

On the Stranger version of this (https://github.com/moonso/stranger/tree/master/stranger/resources) we added a couple of keys, notably pathogenic_min and normal_max that we use for quick clinical triage. I don't know if you would be interested in those as well? There may be some controversy on a couple of them, like pathogenicity for ATXN8OS or non-interrupted vs interrupted allele sizes for e.g. ATXN1.