### PR TITLE
Skip secondary alignments during read recovery

### DIFF
--- a/sample_analysis/MateExtractor.cpp
+++ b/sample_analysis/MateExtractor.cpp
@@ -120,10 +120,19 @@ namespace htshelpers
 
         while (sam_itr_next(htsFilePtr_, htsRegionPtr_, htsAlignmentPtr_) >= 0)
         {
+            const bool isSecondaryAlignment = htsAlignmentPtr_->core.flag & BAM_FSECONDARY;
+            const bool isSupplementaryAlignment = htsAlignmentPtr_->core.flag & BAM_FSUPPLEMENTARY;
+            const bool isPrimaryAlignment = !(isSecondaryAlignment || isSupplementaryAlignment);
+            if (!isPrimaryAlignment)
+            {
+                continue;
+            }
+
             Read putativeMate = htshelpers::decodeRead(htsAlignmentPtr_);
 
             const bool belongToSameFragment = read.fragmentId() == putativeMate.fragmentId();
             const bool formProperPair = read.mateNumber() != putativeMate.mateNumber();
+
             if (belongToSameFragment && formProperPair)
             {
                 mateStats = decodeAlignmentStats(htsAlignmentPtr_);

--- a/src/Version.hh
+++ b/src/Version.hh
@@ -28,6 +28,6 @@
 namespace ehunter
 {
 
-const std::string kProgramVersion = "Expansion Hunter v3.2.0";
+const std::string kProgramVersion = "Expansion Hunter v3.2.2";
 
 }


### PR DESCRIPTION
This pull request will fix a bug caused by secondary alignments with an empty sequence.