### PR TITLE
Remove field shadowing superclass field

### DIFF
--- a/region_analysis/RepeatAnalyzer.hh
+++ b/region_analysis/RepeatAnalyzer.hh
@@ -68,7 +68,6 @@ public:
 private:
     graphtools::NodeId repeatNodeId() const { return nodeIds_.front(); }
 
-    GenotyperParameters genotyperParams_;
     const std::string repeatUnit_;
     GraphVariantAlignmentStatsCalculator alignmentStatsCalculator_;
 


### PR DESCRIPTION
I was wondering why ExpansionHunter was sometimes not producing results in some relatively low coverage situations and went looking to see if there were any coverage thresholds hardwired.

I found out about the (undocumented) MinimalLocusCoverage parameter and went to try it. However it had no effect in my examples - only the default threshold of 10 was ever being applied. I tracked the problem down to the fact that RepeatAnalyzer inadvertently contains a field that shadows that of the superclass. Removing that allows the locus-specific coverage thresholds to work.