### PR TITLE
Optimize extractMates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## NOTE:
+This fork of ExpansionHunter contains I/O optimizations that speed up the tool by 2-3x without changing the output. 
+These optimizations bring down the cost of running ExpansionHunter on very large variants catalogs and/or large numbers of samples. 
+These changes are hosted here pending review and incorporation into the main ExpansionHunter repo. 
+
+Compiled binaries for MacOSX and Linux are available in the [`bin`](https://github.com/bw2/ExpansionHunter/tree/master/bin) directory.
+
+---
+
 # Expansion Hunter: a tool for estimating repeat sizes
 
 There are a number of regions in the human genome consisting of repetitions of

--- a/ehunter/core/HtsHelpers.cpp
+++ b/ehunter/core/HtsHelpers.cpp
@@ -110,15 +110,23 @@ public:
 
 static Cache_seq_nt16_str_lc seq_nt16_str_lc;
 
-Read decodeRead(bam1_t* htsAlignPtr)
-{
+ReadId decodeReadId(bam1_t* htsAlignPtr) {
     const uint32_t samFlag = htsAlignPtr->core.flag;
     const bool isFirstMate = samFlag & BAM_FREAD1;
-    const bool isReversed = samFlag & BAM_FREVERSE;
 
     const char* qname(bam_get_qname(htsAlignPtr));
     MateNumber mateNumber = isFirstMate ? MateNumber::kFirstMate : MateNumber::kSecondMate;
     ReadId readId(qname, mateNumber);
+
+    return readId;
+}
+
+Read decodeRead(bam1_t* htsAlignPtr)
+{
+    ReadId readId = decodeReadId(htsAlignPtr);
+
+    const uint32_t samFlag = htsAlignPtr->core.flag;
+    const bool isReversed = samFlag & BAM_FREVERSE;
 
     string bases;
 

--- a/ehunter/core/HtsHelpers.hh
+++ b/ehunter/core/HtsHelpers.hh
@@ -39,6 +39,7 @@ namespace htshelpers
 
 LinearAlignmentStats decodeAlignmentStats(bam1_t* htsAlignPtr);
 bool isPrimaryAlignment(bam1_t* htsAlignPtr);
+ReadId decodeReadId(bam1_t* htsAlignPtr);
 Read decodeRead(bam1_t* htsAlignPtr);
 ReferenceContigInfo decodeContigInfo(bam_hdr_t* htsHeaderPtr);
 

--- a/ehunter/sample/MateExtractor.hh
+++ b/ehunter/sample/MateExtractor.hh
@@ -32,6 +32,7 @@ extern "C"
 #include "htslib/sam.h"
 }
 
+#include "core/GenomicRegion.hh"
 #include "core/Read.hh"
 #include "core/ReferenceContigInfo.hh"
 
@@ -40,6 +41,17 @@ namespace ehunter
 
 namespace htshelpers
 {
+
+
+// Represents one or more mates that need to be recovered from a specific genomic region.
+struct MateRegionToRecover {
+    GenomicRegion genomicRegion;
+
+    //stores the ReadId of each mate that needs to be recovered from the genomicRegion
+    std::unordered_set<ReadId, boost::hash<ReadId>> mateReadIds;
+};
+
+
 class MateExtractor
 {
 public:
@@ -48,6 +60,7 @@ public:
 
     boost::optional<Read>
     extractMate(const Read& read, const LinearAlignmentStats& alignmentStats, LinearAlignmentStats& mateStats);
+    std::vector<std::pair<Read, LinearAlignmentStats>> extractMates(const MateRegionToRecover& mateRegionToRecover);
 
 private:
     void openFile();


### PR DESCRIPTION
When mates mismap to the same remote region of the genome, group them into intervals that can be fetched in a single I/O operation to improve I/O speed.