### PR TITLE
add flexibility to index search

### DIFF
--- a/ehunter/io/ParameterLoading.cpp
+++ b/ehunter/io/ParameterLoading.cpp
@@ -163,11 +163,11 @@ static void assertPathToExistingFile(const string& pathEncoding)
 
 static void assertIndexExists(const string& htsFilePath)
 {
-    const vector<string> kPossibleIndexExtensions = { ".bai", ".csi", ".crai" };
+    const vector<string> kPossibleIndexExtensions = { ".bai", ".bam.bai", ".csi", ".bam.csi", ".cram.csi", ".crai", ".cram.crai" };
 
     for (const string& indexExtension : kPossibleIndexExtensions)
     {
-        if (fs::exists(htsFilePath + indexExtension))
+        if (fs::exists(htsFilePath.substr(0, htsFilePath.find_last_of(".")) + indexExtension))
         {
             return;
         }

--- a/ehunter/thirdparty/graph-tools-master-0cd9399/src/graphcore/GraphCoordinates.cpp
+++ b/ehunter/thirdparty/graph-tools-master-0cd9399/src/graphcore/GraphCoordinates.cpp
@@ -22,6 +22,8 @@
 #include "graphutils/PairHashing.hh"
 
 #include <cassert>
+#include <stdexcept>
+#include <limits>
 
 namespace graphtools
 {


### PR DESCRIPTION
Instead of requiring the index to be named prefix.bam/.cram + index extension, this pull request allows for the index to be named prefix + index extension. I've essentially just removed the extension from `htsFilePath`, and added more options to `kPossibleIndexExtensions` to account for these differences.

Addresses issue: https://github.com/Illumina/ExpansionHunter/issues/98, as some software generates prefix.bai, not prefix.bam.bai.

So far, I've only tested on prefix.bam & prefix.bai, which now works for me. I'm not sure if anything is missing from the list of possible extensions, so feel free to make edits as needed and let me know if you have any comments. Thanks!