### PR TITLE
Bump gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ ExternalProject_Add(spdlog
 
 
 ExternalProject_Add(googletest
-	URL https://github.com/google/googletest/archive/refs/tags/release-1.10.0.tar.gz
+	URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz
 	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${installDir}
 		-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
 		-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}


### PR DESCRIPTION
This fixes the compilation error that occurs with the current version:
```
error: definition of implicit copy constructor for 'HasSubstrMatcher<std::string>' is deprecated because it has a user-
declared copy assignment operator [-Werror,-Wdeprecated-copy]
```