### PR TITLE
docs: make licensing of repository internally consistent

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,18 +1,30 @@
+
+Copyright [yyyy] [name of copyright owner]
+
+
+
+
+
 Expansion Hunter
+
+Current long term maintenance of open source fork (post v5.0.0):
+Copyright 2023 Lightning Auriga
+
+Original copyright notice (through v5.0.0; edited to Apache 2 for
+consistency with the v5.0.0 LICENSE file):
 Copyright (c) 2016 Illumina, Inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-at your option) any later version.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 
 ******************************************************************

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,10 +1,3 @@
-
-Copyright [yyyy] [name of copyright owner]
-
-
-
-
-
 Expansion Hunter
 
 Current long term maintenance of open source fork (post v5.0.0):

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # Expansion Hunter: a tool for estimating repeat sizes
 
+
+## Overview of long-term OSS maintenance fork
+
+ExpansionHunter was converted from open (Apache 2 or GPL 3) to Polyform Strict
+licensing after v5.0.0. This fork is designed to preserve the open source
+codebase used in the releases up to and including v5.0.0, and to provide
+a repo for maintenance patches moving forward.
+
+
+### Licensing
+
+As of v5.0.0, licensing of the codebase was ambiguous. The LICENSE.txt
+file included in the repository was Apache 2, and all source contributions
+outside of third party content are Apache 2. However, the COPYRIGHT.txt file
+in the repo lists the package as being GPL 3. The LICENSE and COPYRIGHT
+files are thus in conflict in v5.0.0. Based on file editing times and the
+preponderance of code contributions, it appears in this case that the GPL
+addition was made in error, and in fact the code base was predominantly
+made with the intention of creating an Apache 2 project. As such, to try
+to create an internally consistent license state that respects the history
+of the repository as best as possible, the COPYRIGHT text is being adjusted
+to be consistent with the existing LICENSE file for all releases after v5.0.0.
+
+
+## Original overview from ExpansionHunter repo
+
+
+
 There are a number of regions in the human genome consisting of repetitions of
 short unit sequence (commonly a trimer). Such repeat regions can expand to a
 size much larger than the read length and thereby cause a disease.


### PR DESCRIPTION
The v5.0.0 release of this repo contained Apache 2 code contributions and LICENSE file, but GPL 3 COPYRIGHT statement. Due to the preponderance of Apache contributions in this instance, for future releases this information is being harmonized to reflect the Apache license exclusively.