### PR TITLE
Updating old Boost artifactory link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 ExternalProject_Add(Boost
 	BUILD_IN_SOURCE YES
-	URL https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2
+	URL https://archives.boost.io/release/1.73.0/source/boost_1_73_0.tar.bz2
 	PATCH_COMMAND ${BOOST_PATCH_COMMAND}
 	CONFIGURE_COMMAND ./bootstrap.sh --prefix=${installDir}
 	BUILD_COMMAND ./b2 install -j8  --with-filesystem --with-system --with-program_options link=static ${B2_OPTIONS}


### PR DESCRIPTION
- The JFrog artifactory link is very outdated. It is not possible to build from anymore, it seems the boost org has stopped paying for the artifactory.

Allows building from source again (: